### PR TITLE
♻️ Autocollapse completed sections

### DIFF
--- a/interactive/src/App.jsx
+++ b/interactive/src/App.jsx
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 import logo from './logo.jsx.svg';
 import './nmind.orgExcerpts.css';
+import { React } from 'react';
 import './App.css';
 import { Checklist } from './components/Checklist';
 import Footer from './components/Footer';

--- a/interactive/src/components/Footer.jsx
+++ b/interactive/src/components/Footer.jsx
@@ -11,7 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
-import { PureComponent } from 'react';
+import { PureComponent, React } from 'react';
 import { dom } from '@fortawesome/fontawesome-svg-core'
 import yaml from 'js-yaml';
 
@@ -41,7 +41,7 @@ export default class Footer extends PureComponent {
 
   render() {
     const { footer } = this.state;
-    const footerLinks = footer.hasOwnProperty('links') ? footer.links : [];
+    const footerLinks = Object.prototype.hasOwnProperty.call(footer, 'links') ? footer.links : [];
     dom.watch();
     return (
     <div id="footer" className="page__footer"><footer>

--- a/interactive/src/components/ProgressLabelled.js
+++ b/interactive/src/components/ProgressLabelled.js
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react';
+import { PureComponent, React } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Checkbox, CircularProgress, ListItem, ListItemText, Typography } from '@mui/material';
 

--- a/interactive/src/components/Tier.jsx
+++ b/interactive/src/components/Tier.jsx
@@ -35,26 +35,29 @@ class Tier extends PureComponent {
     const override = overrides.includes(`${tier}-${section}`);
     const allChecked = checkNumerator(tier, section) >= checkDenominator(tier, section);
     let nowExpanded = expanded;
-    if (!override) {
-      if (Object.prototype.hasOwnProperty.call(tiers[tier], 'prerequisiteTiers')) {
-        let prereqs = [];
-          tiers[tier].prerequisiteTiers.forEach(prereq => {
-            const numerator = checkNumerator(prereq, section);
-            const denominator = checkDenominator(prereq, section);
-            prereqs.push(numerator >= denominator);
-          });
-        if (prereqs.every(item => item === true)) {
-          // expand when all prerequisites are met
-          nowExpanded = !allChecked;
-        }
-      } else if (!allChecked) {
-        nowExpanded = true;
-      } else if (allChecked) {
-        nowExpanded = false;
+    if (Object.prototype.hasOwnProperty.call(tiers[tier], 'prerequisiteTiers')) {
+      let prereqs = [];
+        tiers[tier].prerequisiteTiers.forEach(prereq => {
+          const numerator = checkNumerator(prereq, section);
+          const denominator = checkDenominator(prereq, section);
+          prereqs.push(numerator >= denominator);
+        });
+      if (prereqs.every(item => item === true)) {
+        // expand when all prerequisites are met
+        nowExpanded = !allChecked;
       }
-    } else if ((!allChecked && expanded ) || (allChecked && !expanded)) {
-      // turn off override if it matches the automatic state
-      toggleTier(null, tier, section);
+    } else if (!allChecked) {
+      nowExpanded = true;
+    } else if (allChecked) {
+      nowExpanded = false;
+    }
+    if (override) {
+      if (nowExpanded === expanded ) {
+        // turn off override if it matches the automatic state
+        toggleTier(null, tier, section);
+      } else {
+        return state;
+      }
     }
     return {expanded: nowExpanded};
   }


### PR DESCRIPTION
Resolves #37

When all checks in a section are completed, collapse that section and expand the subsequent.

### Before this PR
[before this PR: only autoexpands](https://user-images.githubusercontent.com/5974438/194902564-2ead9485-a911-433f-a500-636e3feaaf39.webm)

### After this PR
[after this PR: autocollapses & autoexpands](https://user-images.githubusercontent.com/5974438/194902593-935c76dc-173b-4835-b207-153fc9fca0dd.webm)

## Technical details
Moves the state for overridden collapses (from clicking section-tier headers) from the `<Tier>` component https://github.com/nmind/standards-checklist/blob/8d8104607739eb9c6079385e59d7610879d6d1af/interactive/src/components/Tier.jsx#L17 to the `<Checklist>` component https://github.com/nmind/standards-checklist/blob/5359ebcbc3640a97baf73451de7f6e5263f7755b/interactive/src/components/Checklist.jsx#L84