### PR TITLE
Add clarification to version control

### DIFF
--- a/app/src/schema.json
+++ b/app/src/schema.json
@@ -219,6 +219,7 @@
             "2": {
               "type": "boolean",
               "title": "Package is under version control",
+              "description": "(i.e., traceable history of changes; e.g. commit hash, version tags)",
               "default": false
             },
             "3": {

--- a/checklists/checklist.json
+++ b/checklists/checklist.json
@@ -142,6 +142,7 @@
     {
       "id": "bronze_inf_2",
       "prompt": "Package is under version control",
+      "clarification": "i.e., traceable history of changes; e.g. commit hash, version tags",
       "tier": "bronze",
       "section": "infrastructure",
       "type": "checkbox"


### PR DESCRIPTION
This PR adds a clarification to the version control - that is some traceable history (e.g. commit hash, version tag, etc.) I tried to keep this in a similar style to other clarification points.

