### PR TITLE
Add checklist submission button

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ renders under the **Bronze** heading as the checklist item:
 
 > * [ ] Landing page (e.g., GitHub README, website) provides a link to documentation and brief description of what program does
 
+## Workflow
+
+The workflow to add a new tool to the proceedings page is as follows:
+
+```mermaid
+flowchart LR
+  A(User checklist submission) --> B(Github Issue)
+  B --> C(Checklist review)
+  C --> D{Approved?}
+  D -->|No| E(Revision)
+  E --> C
+  D -->|Yes| F(Added to proceedings)
+```
+
+1. User submits checklist from the [web app](https://nmind.org/standards-checklist)
+2. An issue is created from submitted checklist
+3. Review process with NMIND moderator via created issue
+4. When approved (addition of `approved` label), user submission is added to the [checklist](https://nmind.org/proceedings) via CI.
+
+
+
 ---
 
 Inspired by the [original hackmd document](https://hackmd.io/@mathiasg/SJCPHKZKu).

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,22 +1,22 @@
-import React, { useState } from 'react';
-import { JsonForms } from '@jsonforms/react';
 import { createAjv } from '@jsonforms/core';
+import { JsonForms } from '@jsonforms/react';
+import { useState } from 'react';
 
 import './App.css';
 
-import check from './schema.json';
 import {
-  materialRenderers,
   materialCells,
+  materialRenderers,
 } from '@jsonforms/material-renderers';
+import check from './schema.json';
 
 // material design button component
-import { Button, AppBar, Container, Toolbar, Typography } from '@mui/material';
+import { AppBar, Button, Container, Toolbar, Typography } from '@mui/material';
 
-import { downloadJson, downloadCsv, tableToCSV, jsonSchemaGenerateDefaultObject, uploadJson } from './utils';
+import { downloadCsv, downloadJson, jsonSchemaGenerateDefaultObject, submitJson, tableToCSV, uploadJson } from './utils';
 
-import CustomGroupRenderer, { CustomGroupTester } from './GroupRenderer';
 import CustomCheckboxRenderer, { CustomCheckboxControlTester } from './CheckboxRenderer';
+import CustomGroupRenderer, { CustomGroupTester } from './GroupRenderer';
 
 import { Theme, ThemeProvider, createTheme } from '@mui/material/styles';
 
@@ -117,23 +117,36 @@ function App() {
           uischema={uiSchema}
         />
         <h2>Data</h2>
-        <div style={{ display: "flex", alignItems: "center" }}>
-          <Button variant="contained" onClick={() => downloadJson(JSON.stringify(data, null, 2), data?.name ? "checklist-" + data?.name : "checklist")}>
-            Export JSON
-          </Button>
-          <span style={{ paddingLeft: "1em" }} />
-          <Button variant="contained" onClick={() => downloadCsv(tableToCSV(dataToTable(data)), data?.name ? "checklist-" + data?.name : "checklist")}>
-            Export CSV
-          </Button>
-          <span style={{ paddingLeft: "1em" }} />
-          <Button variant="contained" onClick={async () => {
-            const json = await uploadJson();
-            if (json) {
-              setData(json);
-            }
-          }}>
-            Import JSON
-          </Button>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div>
+            <Button variant="contained" onClick={() => downloadJson(JSON.stringify(data, null, 2), data?.name ? "checklist-" + data?.name : "checklist")}>
+              Export JSON
+            </Button>
+            <span style={{ paddingLeft: "1em" }} />
+            <Button variant="contained" onClick={() => downloadCsv(tableToCSV(dataToTable(data)), data?.name ? "checklist-" + data?.name : "checklist")}>
+              Export CSV
+            </Button>
+            <span style={{ paddingLeft: "1em" }} />
+            <Button variant="contained" onClick={async () => {
+              const json = await uploadJson();
+              if (json) {
+                setData(json);
+              }
+            }}>
+              Import JSON
+            </Button>
+          </div>
+          <div>
+            <Button variant="outlined" onClick={() => submitJson(data)} sx={{
+              transition: 'background-color 0.1s ease, color 0.1s ease',
+              '&:hover': {
+                'backgroundColor': '#1976D2',
+                'color': '#fff',
+              },
+            }}>
+              <strong>Submit</strong>
+            </Button>
+          </div>
         </div>
       </div>
     </ThemeProvider>

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,38 +1,39 @@
 /**
  * Generates a default object from a JSON schema.
- * 
+ *
  * Fills in all default values and empty arrays/objects recursively.
- * 
+ *
  * @param schema JSON schema
  * @returns default object
  */
 export function jsonSchemaGenerateDefaultObject(schema: any): any {
-  if (schema.type === 'object') {
+  if (schema.type === "object") {
     const defaultObject: any = {};
 
     for (const propertyName in schema.properties) {
       if (schema.properties.hasOwnProperty(propertyName)) {
         const propertySchema = schema.properties[propertyName];
 
-        if (propertySchema.hasOwnProperty('default')) {
+        if (propertySchema.hasOwnProperty("default")) {
           defaultObject[propertyName] = propertySchema.default;
         } else {
-          defaultObject[propertyName] = jsonSchemaGenerateDefaultObject(propertySchema);
+          defaultObject[propertyName] =
+            jsonSchemaGenerateDefaultObject(propertySchema);
         }
       }
     }
 
     return defaultObject;
-  } else if (schema.type === 'array') {
-    if (schema.hasOwnProperty('default')) {
+  } else if (schema.type === "array") {
+    if (schema.hasOwnProperty("default")) {
       return schema.default;
-    } else if (schema.hasOwnProperty('items')) {
+    } else if (schema.hasOwnProperty("items")) {
       return [jsonSchemaGenerateDefaultObject(schema.items)];
     } else {
       return [];
     }
   } else {
-    if (schema.hasOwnProperty('default')) {
+    if (schema.hasOwnProperty("default")) {
       return schema.default;
     } else {
       return undefined;
@@ -43,9 +44,9 @@ export function jsonSchemaGenerateDefaultObject(schema: any): any {
 /** Upload JSON */
 export function uploadJson(): Promise<any> {
   return new Promise((resolve, reject) => {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.json';
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
     input.onchange = () => {
       if (input.files && input.files.length > 0) {
         const file = input.files[0];
@@ -60,7 +61,7 @@ export function uploadJson(): Promise<any> {
         };
         reader.readAsText(file);
       } else {
-        reject('No file selected');
+        reject("No file selected");
       }
     };
     input.click();
@@ -69,42 +70,97 @@ export function uploadJson(): Promise<any> {
 
 /** Utility function for downloading files in the browser */
 function downloadTextFile(content: string, mimeType: string, filename: string) {
-  const a = document.createElement("a")
-  a.href = URL.createObjectURL(
-    new Blob([content], { type: mimeType })
-  )
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(new Blob([content], { type: mimeType }));
   a.download = filename;
-  a.click()
+  a.click();
   document.body.removeChild(a);
 }
 
 /**
  * Downloads a JSON file with the given name and content.
- * 
+ *
  * @param content JSON content.
  * @param filename Download filename. Will be sanitized and .json appended.
  */
 export function downloadJson(content: string, filename: string) {
-  downloadTextFile(content, "application/json", `${filename.replace(/\W/g, '_')}.json`);
+  downloadTextFile(
+    content,
+    "application/json",
+    `${filename.replace(/\W/g, "_")}.json`
+  );
+}
+
+/**
+ * Utility function to check tool name has been provided
+ *
+ * @param content JSON content
+ */
+export function checkName(content: string) {
+  let parsedContent = JSON.parse(content);
+
+  if (!parsedContent.hasOwnProperty("name")) {
+    console.error("Error: Tool name was not provided");
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Submit the form as a JSON to the github actions endpoint to create a new PR.
+ * (Update to use NMIND gitEndpoint)
+ * Uses https://github.com/apps/public-action-trigger?ref=benkaiser.dev app to avoid exposing tokens
+ *
+ * @param content JSON content
+ */
+export function submitJson(content: string) {
+  const contentString = JSON.stringify(content, null, 2);
+
+  if (!checkName(contentString)) {
+    console.error("Missing software name");
+    alert("Error: Please provide software name");
+    return;
+  }
+
+  const toolContent = JSON.parse(contentString);
+  const codeBlock = `\`\`\`json\n${contentString}\n\`\`\``;
+  const gitEndpoint = `https://github.com/nmind/proceedings/issues/new?assignees=&labels=checklist&projects=&template=checklist.yaml&title=Checklist%3A+${encodeURIComponent(
+    toolContent.name
+  )}&checklist=${encodeURIComponent(codeBlock)}`;
+
+  const newWindow = window.open(gitEndpoint, "_blank");
+  if (newWindow) {
+    setTimeout(() => {
+      window.location.reload();
+    }, 500);
+  } else {
+    console.error("Failed to submit checklist");
+    alert("Error: Failed to submit checklist, please try again.");
+  }
 }
 
 /**
  * Downloads a CSV file with the given name and content.
- * 
+ *
  * @param csvString CSV content.
  * @param filename Download filename. Will be sanitized and .csv appended.
  */
 export function downloadCsv(csvString: string, filename: string) {
-  downloadTextFile(csvString, "text/csv", `${filename.replace(/\W/g, '_')}.csv`);
+  downloadTextFile(
+    csvString,
+    "text/csv",
+    `${filename.replace(/\W/g, "_")}.csv`
+  );
 }
 
 /**
  * Converts a table to a CSV string.
- * 
+ *
  * The table is an array of rows, where each row is an array of cells.
- * 
+ *
  * The CSV string will be quoted and escaped.
- * 
+ *
  * @param table Table to convert
  * @returns CSV string
  */
@@ -112,39 +168,43 @@ export function tableToCSV(table: any[][]): string {
   const csvRows: string[] = [];
 
   for (const row of table) {
-    const csvRow = row.map((entry) => {
-      if (typeof entry === 'string') {
-        // Quote string values and escape any double quotes inside the string
-        return `"${entry.replace(/"/g, '""')}"`;
-      }
-      return entry.toString();
-    }).join(',');
+    const csvRow = row
+      .map((entry) => {
+        if (typeof entry === "string") {
+          // Quote string values and escape any double quotes inside the string
+          return `"${entry.replace(/"/g, '""')}"`;
+        }
+        return entry.toString();
+      })
+      .join(",");
 
     csvRows.push(csvRow);
   }
 
-  return csvRows.join('\n');
+  return csvRows.join("\n");
 }
 
 /**
  * Counts the number of true values in an object.
- * 
+ *
  * @param obj Object to count
  * @returns Number of true values
  */
 export function dictAllTrue(obj: { [key: string]: boolean }): boolean {
-  return Object.values(obj).every(v => v === true);
+  return Object.values(obj).every((v) => v === true);
 }
 
 /**
  * Returns a string representation of the fraction of true values in an object.
- * 
+ *
  * @param obj Object to count
  * @returns String representation of the fraction of true values
  */
-export function dictFractionTrueString(obj: { [key: string]: boolean }): string {
+export function dictFractionTrueString(obj: {
+  [key: string]: boolean;
+}): string {
   const total = Object.values(obj).length;
-  const trueCount = Object.values(obj).filter(v => v === true).length;
+  const trueCount = Object.values(obj).filter((v) => v === true).length;
 
   return `${trueCount}/${total}`;
 }


### PR DESCRIPTION
This PR is part of a bigger group of PRs across the proceedings and checklist repos to add functionality for simplifying / streamlining the checklist submission process.

This adds submission button to the checklist page (in a contrasting color). A github account will be required in order to submit the checklist in order to facilitate communication with the checklist submitter. If the required software name field is not provided, an alert window pops up to inform the user and prevents submission. If the checklist is valid (e.g. has a name), then upon successful submission, the new issue page is opened with the issue contents prefilled, while the checklist page refreshes.

![image](https://github.com/user-attachments/assets/c88f53d7-2613-450c-b6de-dc69c7cedc89)

_An unintended consequence was the code formatting update._

Also added to the README, is the workflow of the submission process from the web app to getting it added to the proceedings.